### PR TITLE
Turn off force alignment during validation

### DIFF
--- a/examples/speechlm2/s2s_duplex_stt_infer.py
+++ b/examples/speechlm2/s2s_duplex_stt_infer.py
@@ -48,6 +48,7 @@ def inference(cfg):
         input_roles=cfg.data.input_roles,
         output_roles=cfg.data.output_roles,
         include_turn_metadata=True,  # Enable detailed turn metadata for validation
+        force_align_user_text=False,
     )
     datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
 

--- a/examples/speechlm2/s2s_duplex_stt_train.py
+++ b/examples/speechlm2/s2s_duplex_stt_train.py
@@ -52,7 +52,7 @@ def train(cfg):
     with trainer.init_module():
         model = DuplexSTTModel(OmegaConf.to_container(cfg, resolve=True))
 
-    dataset = DuplexS2SDataset(
+    train_dataset = DuplexS2SDataset(
         tokenizer=model.tokenizer,
         frame_length=cfg.data.frame_length,
         source_sample_rate=cfg.data.source_sample_rate,
@@ -63,7 +63,19 @@ def train(cfg):
         cfg=cfg.data,
         model_cfg=cfg.model,
     )
-    datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
+    val_dataset = DuplexS2SDataset(
+        tokenizer=model.tokenizer,
+        frame_length=cfg.data.frame_length,
+        source_sample_rate=cfg.data.source_sample_rate,
+        target_sample_rate=cfg.data.target_sample_rate,
+        input_roles=cfg.data.input_roles,
+        output_roles=cfg.data.output_roles,
+        aug_by_swap_role=cfg.data.get("aug_by_swap_role", False),
+        cfg=cfg.data,
+        model_cfg=cfg.model,
+        force_align_user_text=False,
+    )
+    datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=train_dataset, val_dataset=val_dataset)
 
     trainer.fit(model, datamodule)
 

--- a/nemo/collections/speechlm2/data/datamodule.py
+++ b/nemo/collections/speechlm2/data/datamodule.py
@@ -57,7 +57,7 @@ class DataModule(LightningDataModule):
             The data sampling is controlled by Lhotse samplers rather than the dataset.
     """
 
-    def __init__(self, cfg, tokenizer: TokenizerSpec, dataset: torch.utils.data.Dataset) -> None:
+    def __init__(self, cfg, tokenizer: TokenizerSpec, dataset: torch.utils.data.Dataset, val_dataset: torch.utils.data.Dataset = None) -> None
         super().__init__()
         self.cfg = cfg
         with open_dict(self.cfg):
@@ -67,6 +67,7 @@ class DataModule(LightningDataModule):
                     getattr(self.cfg, k).force_map_dataset = True
         self.tokenizer = tokenizer
         self.dataset = dataset
+        self.val_dataset = val_dataset if val_dataset is not None else dataset
 
     def train_dataloader(self):
         if "train_ds" not in self.cfg:
@@ -120,7 +121,7 @@ class DataModule(LightningDataModule):
                 config=cfg,
                 global_rank=self._get_dp_rank(),
                 world_size=self._get_world_size(),
-                dataset=self.dataset,
+                dataset=self.val_dataset,
                 tokenizer=self.tokenizer,
             )
 

--- a/nemo/collections/speechlm2/data/s2s_dataset.py
+++ b/nemo/collections/speechlm2/data/s2s_dataset.py
@@ -110,6 +110,7 @@ class DuplexS2SDataset(torch.utils.data.Dataset):
         include_turn_metadata: bool = False,
         cfg: dict = None,
         model_cfg: dict = None,
+        force_align_user_text: bool = None,
     ):
         self.tokenizer = tokenizer
         self.frame_length = frame_length
@@ -122,7 +123,14 @@ class DuplexS2SDataset(torch.utils.data.Dataset):
 
         self.word_align_position = cfg.get("word_align_position", "left") if cfg is not None else "left"
         self.predict_user_text = model_cfg.get("predict_user_text", False) if model_cfg is not None else False
-        self.force_align_user_text = model_cfg.get("force_align_user_text", False) if model_cfg is not None else None
+
+        # Force alignment settings: use explicit parameter if provided, otherwise fall back to config
+        if force_align_user_text is not None:
+            self.force_align_user_text = force_align_user_text
+        else:
+            self.force_align_user_text = model_cfg.get("force_align_user_text", False) if model_cfg is not None else False
+
+
         # Default to CPU for force alignment to avoid OOM during training/validation when main model is on GPU
         self.force_align_device = model_cfg.get("force_align_device", "cpu") if model_cfg is not None else "cpu"
 
@@ -145,10 +153,10 @@ class DuplexS2SDataset(torch.utils.data.Dataset):
         self.user_bos_id = self.tokenizer.text_to_ids(user_bos_token)[0]
         self.user_eos_id = self.tokenizer.text_to_ids(user_eos_token)[0]
 
-        # Initialize force aligner if needed
+        # Initialize force aligner lazily (only when needed during training)
+        # This avoids loading the wav2vec2 model during validation
         self.force_aligner = None
-        if self.force_align_user_text:
-            self.force_aligner = ForceAligner(device=self.force_align_device, frame_length=self.frame_length)
+        self._force_aligner_initialized = False
         
         assert tokenizer.bos is not None, "BOS support in the tokenizer is required for S2S models."
         assert tokenizer.eos is not None, "EOS support in the tokenizer is required for S2S models."
@@ -318,8 +326,14 @@ class DuplexS2SDataset(torch.utils.data.Dataset):
                 all_cuts_combined, self.tokenizer, self.frame_length, roles=self.output_roles, bos_id=self.tokenizer.bos, eos_id=self.tokenizer.eos, remove_timestamps=True
             )
 
-            # Only run force alignment during training (when gradients are enabled)
-            if self.force_align_user_text and torch.is_grad_enabled():
+            # Run force alignment if enabled
+            # NOTE: For validation, create a separate dataset instance with force_align_user_text=False
+            if self.force_align_user_text:
+                # Only create ForceAligner when first needed
+                if not self._force_aligner_initialized:
+                    logging.info(f"Initializing ForceAligner on device {self.force_align_device}")
+                    self.force_aligner = ForceAligner(device=self.force_align_device, frame_length=self.frame_length)
+                    self._force_aligner_initialized = True
                 logging.info(f"Force aligning user text for {len(all_cuts_combined)} cuts on device {self.force_align_device}")
                 all_cuts_combined = self.force_aligner.batch_force_align_user_audio(all_cuts_combined, source_sample_rate=self.source_sample_rate)
                 


### PR DESCRIPTION
# What does this PR do ?

Disabled force alignment during validation. 

The script now initializes a separate dataloader for validation data which we can use to turn off force alignment just for validation. 

The previous code had `if self.force_align_user_text and torch.is_grad_enabled():` but that does not help for validation runs during training. `torch.is_grad_enabled()` returns True within the scope of s2s_dataset.

Before I made this change I kept getting force alignment OOM and nccl timeout errors in 20% of the runs using [this branch](https://github.com/ankitapasad/NeMo/tree/duplex-s2s-nov). Since these changes, all experiments have been running smoothly. 
