### PR TITLE
Trim audio to the original length before saving

### DIFF
--- a/nemo/collections/speechlm2/models/nemotron_voicechat.py
+++ b/nemo/collections/speechlm2/models/nemotron_voicechat.py
@@ -404,6 +404,7 @@ class NemotronVoiceChat(LightningModule, HFHubMixin):
                     pred_audio_sr=self.target_sample_rate,
                     user_audio=dataset_batch["source_audio"],
                     user_audio_sr=self.source_sample_rate,
+                    audio_lens=dataset_batch["source_audio_lens"] + input_pad_len,
                     eou_pred=(
                         results["gen_eou"]
                         if "gen_eou" in results

--- a/nemo/collections/speechlm2/parts/metrics/results_logger.py
+++ b/nemo/collections/speechlm2/parts/metrics/results_logger.py
@@ -123,6 +123,7 @@ class ResultsLogger:
         pred_audio_sr: int,
         user_audio: torch.Tensor,
         user_audio_sr: int,
+        audio_lens: torch.Tensor = None,
         target_audio: torch.Tensor = None,
         pred_audio_tf: torch.Tensor = None,
         pre_audio_trimmed: torch.Tensor = None,
@@ -141,11 +142,23 @@ class ResultsLogger:
             out_audio_path = os.path.join(self.audio_save_path, f"{name}_{sample_id}.wav")
             agent_out_audio_path = os.path.join(self.agent_audio_save_path, f"{name}_{sample_id}.wav")
             user_out_audio_path = os.path.join(self.user_audio_save_path, f"{name}_{sample_id}.wav")
+
+            # Trim batch-padded audio to per-sample actual length to remove
+            # trailing silence introduced by batching samples of different lengths.
+            cur_user_audio = user_audio[i] if user_audio is not None else None
+            cur_pred_audio = pred_audio[i]
+            if audio_lens is not None and cur_user_audio is not None:
+                actual_user_len = int(audio_lens[i].item())
+                cur_user_audio = cur_user_audio[:actual_user_len]
+                # Trim pred_audio to the equivalent duration (resampled to pred SR)
+                actual_pred_len = int(actual_user_len / user_audio_sr * pred_audio_sr)
+                cur_pred_audio = cur_pred_audio[:actual_pred_len]
+
             self.merge_and_save_audio(
                 out_audio_path,
-                pred_audio[i],
+                cur_pred_audio,
                 pred_audio_sr,
-                user_audio[i] if user_audio is not None else None,
+                cur_user_audio,
                 user_audio_sr,
                 agent_out_audio_path=agent_out_audio_path,
                 user_out_audio_path=user_out_audio_path,


### PR DESCRIPTION
Before this PR: The predictions for frames padded to the batch of audios was also saved in predicted audio.
After this PR: The padded portion is trimmed before saving.

The saved audio includes `model.extra_decoding_seconds` duration. 

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]
speechlm2